### PR TITLE
Changed the snooze confirmation message.

### DIFF
--- a/telegram_daemon.py
+++ b/telegram_daemon.py
@@ -53,7 +53,8 @@ class TelegramNotifier:
 
     def snooze(self, update, context):
         """Send a message when the command /start is issued."""
-        update.message.reply_text("You have successfully snoozed the notifications for the day.")
+        update.message.reply_text("You have successfully snoozed the notifications for the day. " 
+                                  "To resume notifications again, use /removeSnooze.")
         # update to the sqlite table.
         chat = update.message.chat
         self.db_manager.snooze(chat.id)


### PR DESCRIPTION
Changed the `/snooze` confirmation message from `You have successfully snoozed the notifications for the day.` to `You have successfully snoozed the notifications for the day. To resume notifications again, use /removeSnooze.`

Since the user is likely to resume notifications and this change to the message makes the command `/removeSnooze` directly available with a single tap.